### PR TITLE
Rename Drupal\integration\Tests\Consumer\Migrate

### DIFF
--- a/tests/Document/DocumentTest.php
+++ b/tests/Document/DocumentTest.php
@@ -8,7 +8,7 @@
 namespace Drupal\integration\Tests\Document;
 
 use Drupal\integration\Document\Document;
-use Drupal\integration\Tests\Consumer\Migrate\AbstractMigrateTest;
+use Drupal\integration\Tests\Migrate\AbstractMigrateTest;
 
 /**
  * Class DocumentTest.

--- a/tests/Migrate/AbstractMigrateTest.php
+++ b/tests/Migrate/AbstractMigrateTest.php
@@ -5,14 +5,14 @@
  * Contains AbstractMigrateTest.
  */
 
-namespace Drupal\integration\Tests\Consumer\Migrate;
+namespace Drupal\integration\Tests\Migrate;
 
 /**
  * Class AbstractMigrateTest.
  *
  * @group migrate
  *
- * @package Drupal\integration\Tests\Consumer\Migrate
+ * @package Drupal\integration\Tests\Migrate
  */
 abstract class AbstractMigrateTest extends \PHPUnit_Framework_TestCase {
 

--- a/tests/Migrate/ArticlesMigrationTest.php
+++ b/tests/Migrate/ArticlesMigrationTest.php
@@ -5,7 +5,7 @@
  * Contains ArticlesMigrationTest class.
  */
 
-namespace Drupal\integration\Tests\Consumer\Migrate;
+namespace Drupal\integration\Tests\Migrate;
 
 use Drupal\integration\Document\Document;
 
@@ -14,7 +14,7 @@ use Drupal\integration\Document\Document;
  *
  * @group migrate
  *
- * @package Drupal\integration\Tests\Consumer\Migrate
+ * @package Drupal\integration\Tests\Migrate
  */
 class ArticlesMigrationTest extends AbstractMigrateTest {
 

--- a/tests/Migrate/CategoriesMigrationTest.php
+++ b/tests/Migrate/CategoriesMigrationTest.php
@@ -5,7 +5,7 @@
  * Contains CategoriesMigrationTest class.
  */
 
-namespace Drupal\integration\Tests\Consumer\Migrate;
+namespace Drupal\integration\Tests\Migrate;
 
 use Drupal\integration\Document\Document;
 
@@ -14,7 +14,7 @@ use Drupal\integration\Document\Document;
  *
  * @group migrate
  *
- * @package Drupal\integration\Tests\Consumer\Migrate
+ * @package Drupal\integration\Tests\Migrate
  */
 class CategoriesMigrationTest extends AbstractMigrateTest {
 

--- a/tests/Migrate/DocumentWrapperTest.php
+++ b/tests/Migrate/DocumentWrapperTest.php
@@ -5,7 +5,7 @@
  * Contains \Drupal\integration\Tests\DocumentWrapperTest.
  */
 
-namespace Drupal\integration\Tests\Consumer\Migrate;
+namespace Drupal\integration\Tests\Migrate;
 
 use Drupal\integration\Document\Document;
 use Drupal\integration\Migrate\DocumentWrapper;

--- a/tests/Migrate/NewsMigrationTest.php
+++ b/tests/Migrate/NewsMigrationTest.php
@@ -5,7 +5,7 @@
  * Contains NewsMigrationTest class.
  */
 
-namespace Drupal\integration\Tests\Consumer\Migrate;
+namespace Drupal\integration\Tests\Migrate;
 
 use Drupal\integration\Document\Document;
 
@@ -14,7 +14,7 @@ use Drupal\integration\Document\Document;
  *
  * @group migrate
  *
- * @package Drupal\integration\Tests\Consumer\Migrate
+ * @package Drupal\integration\Tests\Migrate
  */
 class NewsMigrationTest extends AbstractMigrateTest {
 


### PR DESCRIPTION
@imanoleguskiza I've ran tests and they were failing: I had to rename `Drupal\integration\Tests\Consumer\Migrate` into `Drupal\integration\Tests\Migrate` the pull request below should fix them.
